### PR TITLE
Implementing cmap and tests

### DIFF
--- a/src/dolfin_pyvista_adapter/source.py
+++ b/src/dolfin_pyvista_adapter/source.py
@@ -1,7 +1,7 @@
 import dolfin
 import pyvista
 from ufl import vertex
-from typing import Tuple
+from typing import Tuple, Union, List
 import numpy.typing as npt
 import numpy as np
 import pathlib
@@ -96,6 +96,7 @@ def plot(
     show_edges: bool = True,
     glyph_factor: float = 1,
     off_screen: bool = True,
+    cmap: Union[str, List[str]] = "viridis",
 ):
     """
     Plot a (discontinuous) Lagrange function with Pyvista
@@ -106,6 +107,7 @@ def plot(
     :param glyph_factor: Scaling of glyphs if input function is a function from a
       ``dolfin.VectorFunctionSpace``.
     :param off_screen: If ``True`` generate plots with virtual frame buffer using ``xvfb``.
+    :param cmap: The colormap to use. If a string uses matplotlib colormaps, if a list uses strings as colors.
     """
     Vh = uh.function_space()
 
@@ -140,16 +142,16 @@ def plot(
         t1, c1, x1 = create_vtk_structures(P1)
         p1_grid = pyvista.UnstructuredGrid(t1, c1, x1)
         if bs > 1:
-            plotter.add_mesh(p1_grid, show_edges=show_edges)
+            plotter.add_mesh(p1_grid, show_edges=show_edges, cmap=cmap)
         else:
-            plotter.add_mesh(grid)
-            plotter.add_mesh(p1_grid, style="wireframe")
+            plotter.add_mesh(grid, cmap=cmap)
+            plotter.add_mesh(p1_grid, style="wireframe", cmap=cmap)
     else:
-        plotter.add_mesh(grid, show_edges=show_edges)
+        plotter.add_mesh(grid, show_edges=show_edges, cmap=cmap)
 
     if bs > 1:
         glyphs = grid.glyph(orient=uh.name(), factor=glyph_factor)
-        plotter.add_mesh(glyphs)
+        plotter.add_mesh(glyphs, cmap=cmap)
     print(filename)
     if filename is None:
         plotter.show()

--- a/tests/test_3D.py
+++ b/tests/test_3D.py
@@ -27,3 +27,23 @@ def test_plot_scalar_3D(testing_dir):
     u.interpolate(dolfin.Expression("x[0]+3*x[1]+2", degree=1))
     filename = testing_dir / "scalar.png"
     plot(u, filename=filename, show_edges=True)
+
+
+# Test if matplotlib colormaps work
+def test_plot_scalar_3D_cmap(testing_dir):
+    mesh = dolfin.UnitCubeMesh(2, 2, 2)
+    V = dolfin.FunctionSpace(mesh, "Lagrange", 2)
+    u = dolfin.Function(V)
+    u.interpolate(dolfin.Expression("x[0]+3*x[1]+2", degree=1))
+    filename = testing_dir / "scalar_cmap.png"
+    plot(u, filename=filename, show_edges=True, cmap="inferno")
+
+
+# Test if custom colormap works
+def test_plot_scalar_3D_custom_cmap(testing_dir):
+    mesh = dolfin.UnitCubeMesh(2, 2, 2)
+    V = dolfin.FunctionSpace(mesh, "Lagrange", 2)
+    u = dolfin.Function(V)
+    u.interpolate(dolfin.Expression("x[0]+3*x[1]+2", degree=1))
+    filename = testing_dir / "scalar_custom_cmap.png"
+    plot(u, filename=filename, show_edges=True, cmap=["red", "blue", "green"])


### PR DESCRIPTION
Issue #2: Implemented optional changing colourbar and colour. kwargs cmap accepts two different input types: the first is a string which uses matplotlibs colormaps, and the second is a list of strings (colors) for custom colormaps. Also made two tests to verify cmaps work.

Built docker, ran all pytests, all passed. 

Results from pytests:
**Default:**
![scalar](https://github.com/jorgensd/dolfin_pyvista_adapter/assets/57572263/1c76933b-115e-41aa-8272-ad1aaf7f5587)

**Example cmap:**
![scalar_cmap](https://github.com/jorgensd/dolfin_pyvista_adapter/assets/57572263/884291f1-fb82-4a51-ab57-02cec8631102)

**Custom cmap:**
![scalar_custom_cmap](https://github.com/jorgensd/dolfin_pyvista_adapter/assets/57572263/1f6e2690-e3c4-41be-bfbf-5980666550aa)

